### PR TITLE
Reword the error messages for better grammar and clarity.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,33 +56,33 @@ Error codes
 
 This plugin is using the following error codes:
 
-+----------------------------------------------------------------------+
-| Presence of implicit parameters                                      |
-+--------+-------------------------------------------------------------+
-| FMT101 | format string does contain unindexed parameters             |
-+--------+-------------------------------------------------------------+
-| FMT102 | docstring does contain unindexed parameters                 |
-+--------+-------------------------------------------------------------+
-| FMT103 | other string does contain unindexed parameters              |
-+--------+-------------------------------------------------------------+
-| Missing values in the parameters                                     |
-+--------+-------------------------------------------------------------+
-| FMT201 | format call uses too large index (INDEX)                    |
-+--------+-------------------------------------------------------------+
-| FMT202 | format call uses missing keyword (KEYWORD)                  |
-+--------+-------------------------------------------------------------+
-| FMT203 | format call uses keyword arguments but no named entries     |
-+--------+-------------------------------------------------------------+
-| FMT204 | format call uses variable arguments but no numbered entries |
-+--------+-------------------------------------------------------------+
-| FMT205 | format call uses implicit and explicit indexes together     |
-+--------+-------------------------------------------------------------+
-| Unused values in the parameters                                      |
-+--------+-------------------------------------------------------------+
-| FMT301 | format call provides unused index (INDEX)                   |
-+--------+-------------------------------------------------------------+
-| FMT302 | format call provides unused keyword (KEYWORD)               |
-+--------+-------------------------------------------------------------+
++--------+---------------------------------------------------------------------+
+| Presence of implicit parameters                                              |
++--------+---------------------------------------------------------------------+
+| FMT101 | format string contains unindexed parameters                         |
++--------+---------------------------------------------------------------------+
+| FMT102 | docstring contains unindexed parameters                             |
++--------+---------------------------------------------------------------------+
+| FMT103 | other string contains unindexed parameters                          |
++--------+---------------------------------------------------------------------+
+| Missing values in the parameters                                             |
++--------+---------------------------------------------------------------------+
+| FMT201 | format call index too large (INDEX)                                 |
++--------+---------------------------------------------------------------------+
+| FMT202 | format call uses missing keyword (KEYWORD)                          |
++--------+---------------------------------------------------------------------+
+| FMT203 | format call uses keyword arguments but there are no keyword entries |
++--------+---------------------------------------------------------------------+
+| FMT204 | format call uses indexed arguments but there are no indexed entries |
++--------+---------------------------------------------------------------------+
+| FMT205 | format call uses implicit and explicit indexes together             |
++--------+---------------------------------------------------------------------+
+| Unused values in the parameters                                              |
++--------+---------------------------------------------------------------------+
+| FMT301 | format call provides unused index (INDEX)                           |
++--------+---------------------------------------------------------------------+
+| FMT302 | format call provides unused keyword (KEYWORD)                       |
++--------+---------------------------------------------------------------------+
 
 
 Operation

--- a/flake8_string_format.py
+++ b/flake8_string_format.py
@@ -115,13 +115,13 @@ class StringFormatChecker(object):
     name = 'flake8-string-format'
 
     ERRORS = {
-        101: 'format string does contain unindexed parameters',
-        102: 'docstring does contain unindexed parameters',
-        103: 'other string does contain unindexed parameters',
-        201: 'format call uses too large index ({idx})',
+        101: 'format string contains unindexed parameters',
+        102: 'docstring contains unindexed parameters',
+        103: 'other string contains unindexed parameters',
+        201: 'format call index too large ({idx})',
         202: 'format call uses missing keyword ({kw})',
-        203: 'format call uses keyword arguments but no named entries',
-        204: 'format call uses variable arguments but no numbered entries',
+        203: 'format call uses keyword arguments but there are no keyword entries',
+        204: 'format call uses indexed arguments but there are no indexed entries',
         205: 'format call uses implicit and explicit indexes together',
         301: 'format call provides unused index ({idx})',
         302: 'format call provides unused keyword ({kw})',


### PR DESCRIPTION
In particular, it's very unnatural to state that something "does contain" in English, especially when highlighting a problem. You would say it "contains", and only add the extra word when it "doesn't contain". 

I found myself speed reading "does contain" as "doesn't contain" and getting very confused.